### PR TITLE
Redundant type attribute removed

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,9 +9,9 @@
 	<title>css Zen Garden: The Beauty in CSS Design</title>
 
 	<!-- to correct the unsightly Flash of Unstyled Content. http://www.bluerobot.com/web/css/fouc.asp -->
-	<script type="text/javascript"></script>
+	<script></script>
 	
-	<style type="text/css" title="currentStyle" media="screen">
+	<style title="currentStyle" media="screen">
 		@import "/001/001.css";
 	</style>
 	<link rel="Shortcut Icon" type="image/x-icon" href="http://www.csszengarden.com/favicon.ico" />	


### PR DESCRIPTION
Given the HTML5 doctype, it's not required to be using the `type` attribute for the `script` and `style` elements. Said attribute has been removed.
