### PR TITLE
Remove unneeded favicon HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,6 @@
 	<style title="currentStyle" media="screen">
 		@import "/001/001.css";
 	</style>
-	<link rel="Shortcut Icon" type="image/x-icon" href="http://www.csszengarden.com/favicon.ico" />	
 	<link rel="alternate" type="application/rss+xml" title="RSS" href="http://www.csszengarden.com/zengarden.xml" />
 </head>
 


### PR DESCRIPTION
`/favicon.ico` is the implied favicon location, so no HTML is needed in this case. See http://mathiasbynens.be/notes/rel-shortcut-icon for more info.
