### PR TITLE
Only allow `[a-zA-Z0-9$_]` in JSON-P callback names

### DIFF
--- a/submissions.json
+++ b/submissions.json
@@ -1,7 +1,7 @@
 <?php
 
   include($SERVER_ROOT . 'includes/masterlist.php');
-  $callback = isset($_GET['callback']) ? $_GET['callback'] : false;
+  $callback = isset($_GET['callback']) ? preg_replace('/[^a-z0-9$_]/si', '', $_GET['callback']) : false;
   header('Content-Type: ' . ($callback ? 'application/javascript' : 'application/json') . ';charset=utf-8');
 
   function jsonify($entry) {


### PR DESCRIPTION
Ref. https://github.com/mezzoblue/csszengarden.com/pull/24/files#r4150859.
