### PR TITLE
Fix include of masterlist.php in all tr/*/index.php

### DIFF
--- a/tr/Blank/index.php
+++ b/tr/Blank/index.php
@@ -1,6 +1,6 @@
 <?php
 
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 $letterarray = array("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m");
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/tr/chinese/index.php
+++ b/tr/chinese/index.php
@@ -1,7 +1,7 @@
 ﻿<?php
 
 $loadCSS = "/001/001-zh.css";
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 $letterarray = array("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m");
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/tr/czech/index.php
+++ b/tr/czech/index.php
@@ -1,6 +1,6 @@
 <?php
 
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 $letterarray = array("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m");
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/tr/danish/Copy of index.php
+++ b/tr/danish/Copy of index.php
@@ -1,6 +1,6 @@
 <?php
 
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 $letterarray = array("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m");
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/tr/danish/index.php
+++ b/tr/danish/index.php
@@ -1,6 +1,6 @@
 <?php
 
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 $letterarray = array("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m");
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/tr/deutsch/Copy of index.php
+++ b/tr/deutsch/Copy of index.php
@@ -1,6 +1,6 @@
 <?php
 
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 $letterarray = array("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m");
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/tr/deutsch/index.php
+++ b/tr/deutsch/index.php
@@ -1,6 +1,6 @@
 <?php
 $loadCSS = "/001/001-de.css";
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 $letterarray = array("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m");
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/tr/dutch/Copy of index.php
+++ b/tr/dutch/Copy of index.php
@@ -1,6 +1,6 @@
 <?php
 
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 $letterarray = array("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m");
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/tr/dutch/index.php
+++ b/tr/dutch/index.php
@@ -1,6 +1,6 @@
 <?php
 
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 $letterarray = array("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m");
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/tr/espanol/index.php
+++ b/tr/espanol/index.php
@@ -1,6 +1,6 @@
 <?php
 
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 $letterarray = array("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m");
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/tr/finnish/index.php
+++ b/tr/finnish/index.php
@@ -1,6 +1,6 @@
 <?php
 
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 $letterarray = array("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m");
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/tr/francais/Copy of index.php
+++ b/tr/francais/Copy of index.php
@@ -1,6 +1,6 @@
 <?php
 
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
 	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">

--- a/tr/francais/index.php
+++ b/tr/francais/index.php
@@ -1,7 +1,7 @@
 <?php
 
 $loadCSS = "/001/001-fr.css";
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
 	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">

--- a/tr/greek/index.php
+++ b/tr/greek/index.php
@@ -1,6 +1,6 @@
 <?php
 
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
 	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">

--- a/tr/indonesian/index.php
+++ b/tr/indonesian/index.php
@@ -1,6 +1,6 @@
 <?php
 
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 $letterarray = array("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m");
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/tr/italiano/index.php
+++ b/tr/italiano/index.php
@@ -1,6 +1,6 @@
 <?php
 
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 $letterarray = array("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m");
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/tr/japanese/index.php
+++ b/tr/japanese/index.php
@@ -1,7 +1,7 @@
 <?php
 
 $loadCSS = "/001/001-jp.css";
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 $letterarray = array("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m");
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/tr/japanese/index2.php
+++ b/tr/japanese/index2.php
@@ -1,6 +1,6 @@
 <?php
 
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 $letterarray = array("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m");
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/tr/korean/Copy of index.php
+++ b/tr/korean/Copy of index.php
@@ -1,6 +1,6 @@
 ﻿<?php
 
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 $letterarray = array("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m");
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/tr/korean/index.php
+++ b/tr/korean/index.php
@@ -1,6 +1,6 @@
 ﻿<?php
 
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 $letterarray = array("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m");
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/tr/magyar/index.php
+++ b/tr/magyar/index.php
@@ -1,6 +1,6 @@
 <?php
 
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 $letterarray = array("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m");
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/tr/magyar/index2.php
+++ b/tr/magyar/index2.php
@@ -1,6 +1,6 @@
 <?php
 
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 $letterarray = array("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m");
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/tr/norwegian/index.php
+++ b/tr/norwegian/index.php
@@ -1,6 +1,6 @@
 <?php
 
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 $letterarray = array("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m");
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/tr/polish/index.php
+++ b/tr/polish/index.php
@@ -1,6 +1,6 @@
 <?php
 
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 $letterarray = array("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m");
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/tr/portuguese/index.php
+++ b/tr/portuguese/index.php
@@ -1,6 +1,6 @@
 <?php
 
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 $letterarray = array("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m");
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/tr/romanian/index.php
+++ b/tr/romanian/index.php
@@ -1,6 +1,6 @@
 <?php
 
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 $letterarray = array("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m");
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/tr/russian/index.php
+++ b/tr/russian/index.php
@@ -1,6 +1,6 @@
 <?php
 
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 $letterarray = array("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m");
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/tr/svenska/index.php
+++ b/tr/svenska/index.php
@@ -1,6 +1,6 @@
 <?php
 
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 $letterarray = array("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m");
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/tr/turkish/index.php
+++ b/tr/turkish/index.php
@@ -1,6 +1,6 @@
 <?php
 
-include '../../masterlist.php';
+include '../../includes/masterlist.php';
 $letterarray = array("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m");
 
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"


### PR DESCRIPTION
Hi,
I noticed an error on translated pages:

```
Warning: include(../../masterlist.php) [function.include]: failed to open stream: No such file or directory in /nfs/c02/h05/mnt/22553/domains/csszengarden.com/html/tr/francais/index.php on line 4

Warning: include() [function.include]: Failed opening '../../masterlist.php' for inclusion (include_path='.:/usr/local/php-5.3.15/share/pear') in /nfs/c02/h05/mnt/22553/domains/csszengarden.com/html/tr/francais/index.php on line 4
```

You can see it a live example here: http://csszengarden.com/tr/francais/
And my PR fixes that issue :-)
