### PR TITLE
submissions.json: Enable CORS

### DIFF
--- a/submissions.json
+++ b/submissions.json
@@ -4,6 +4,10 @@
   $callback = isset($_GET['callback']) ? preg_replace('/[^a-z0-9$_]/si', '', $_GET['callback']) : false;
   header('Content-Type: ' . ($callback ? 'application/javascript' : 'application/json') . ';charset=utf-8');
 
+  // There’s no reason not to allow CORS for public APIs.
+  // See http://annevankesteren.nl/2012/12/cors-101 for details.
+  header('Access-Control-Allow-Origin: *');
+
   function jsonify($entry) {
     return array(
       'submission' => $entry[0],


### PR DESCRIPTION
There’s no reason not to allow CORS for public APIs. See http://annevankesteren.nl/2012/12/cors-101 for details.
