### PR TITLE
Suppress warning when an external CSS file is not found.

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -11,7 +11,7 @@
 		$css = false;
 
 		if (preg_match("/^http/", $cssUrl)) {
-			$css = file_get_contents($cssUrl);
+			$css = @file_get_contents($cssUrl);
 		} else if (preg_match("/\d+\/\d+.css$/", $cssUrl)) {
 			$path = realpath(__DIR__ . "/../" . $cssUrl);
 


### PR DESCRIPTION
When going through the list of submissions that "didn't make it" I noticed that it would spit out a warning if the CSS file could no longer be found. This pull requests suppresses that warning.
