### PR TITLE
Fix 500 internal server error when downloading sample html file

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,6 +1,5 @@
 RewriteEngine On
-#Comment the line below if server is already configured to follow symlinks 
-#Options +FollowSymlinks
+Options +FollowSymlinks
 RewriteBase /
 
 # Canonical Host
@@ -28,7 +27,7 @@ deny from env=BadReferrer
 
 # permanent redirect of old example files
 RedirectMatch 301 ^/zengarden-sample\.css$ /examples/style.css
-RedirectMatch 301 ^/zengarden-sample\.html$ /examples/index.html
+RedirectMatch 301 ^/zengarden-sample\.html$ /examples/index
 
 # remove trailing .php from /examples/index.php
 RewriteCond %{REQUEST_FILENAME} !-f


### PR DESCRIPTION
Hi Dave, I'm commenting "Options +FollowSymlinks" - maybe your server is already configured to follow symlinks? I tried loading the files to another server and the sample html file was successfully downloaded. With the "Options +FollowSymlinks" line uncommented the server displays the 500 error page.
