### PR TITLE
Fix html download link under "Participation" section

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -27,7 +27,7 @@ deny from env=BadReferrer
 
 # permanent redirect of old example files
 RedirectMatch 301 ^/zengarden-sample\.css$ /examples/style.css
-RedirectMatch 301 ^/zengarden-sample\.html$ /examples/index.html
+RedirectMatch 301 ^/zengarden-sample\.html$ /examples/index
 
 # remove trailing .php from /examples/index.php
 RewriteCond %{REQUEST_FILENAME} !-f


### PR DESCRIPTION
Removed the .html extension so that it redirects properly.
