### PR TITLE
Fix kits failing to copy

### DIFF
--- a/includes/typekit-client.php
+++ b/includes/typekit-client.php
@@ -76,6 +76,8 @@ class Typekit {
 
 						if (strlen($body) < $size) {
 							$data = $body . fread($socket, $size - strlen($body));
+						} else {
+							$data = $body;
 						}
 
 						if ($this->debug) {


### PR DESCRIPTION
Add missing conditional when a kit is small enough to be read in the first `fread` call. In this case `$body` equals the whole response body and should be assigned to `$data`.
