### PR TITLE
Fix link for "View This Design's CSS"

### DIFF
--- a/includes/tmpl.php
+++ b/includes/tmpl.php
@@ -148,7 +148,7 @@
 				<h3 class="resources"><?php echo $sidebar["design-resources-h3"]; ?></h3>
 				<ul>
 					<li class="view-css">
-						<a href="<?php echo "/$currentDesign/$currentDesign" ?>" title="<?php echo $sidebar["view-css-title"]; ?>">
+						<a href="<?php echo "/$currentStyleSheet" ?>" title="<?php echo $sidebar["view-css-title"]; ?>">
 							<?php echo $sidebar["view-css-text"]; ?>
 						</a>
 					</li>


### PR DESCRIPTION
We've already created the $currentStylesheet variable in functions.php. This should be used to create the correct link for viewing the stylesheet of a currently viewed design. Note: this is untested.
