### PR TITLE
Remove trailing dot from domain name

### DIFF
--- a/includes/masterlist.php
+++ b/includes/masterlist.php
@@ -1287,7 +1287,7 @@ $designList = array(
 			"216",
 			"Fountain Kiss",
 			"Jeremy Carlson",
-			"http://jeremycarlson.com.",
+			"http://jeremycarlson.com",
 	),
 	array(
 			"217",


### PR DESCRIPTION
The HTML validator complains about the trailing dot in entry 216

>  Line 132, Column 126: Bad value http://jeremycarlson.com. for attribute href on element a: Invalid host: DNS violation: Host contains empty label.
> 
> ```
> <a href="http://jeremycarlson.com." class="designer-name">Jeremy Carlson</a>
> ```
