### PR TITLE
Remove disclaimer that is incompatible with CC

### DIFF
--- a/205/205.css
+++ b/205/205.css
@@ -3,12 +3,6 @@
 /* All associated graphics copyright 2006, Rene Hornig */
 
 
-/* IMPORTANT */
-/* This design is not a template. You may not reproduce it elsewhere without the 
-   designer's written permission. However, feel free to study the CSS and use 
-   techniques you learn from it elsewhere. */
-
-
 /* basic elements */
 * {
 	margin: 0;


### PR DESCRIPTION
Style 205 includes a comment to the tune of "you may not reuse this without written permission". However, the design is based on the csszengarden template which is licensed CC-BY-NC-SA. Author does not appear to have rights to the original CSS beyond those given by CC. CC does not give Author the right to redistribute under a more restrictive license than CC.

> No additional restrictions — You may not apply **legal terms** or technological measures that legally restrict others from doing anything the license permits.

The comment in question is thus legally not binding. I've removed it to avoid confusing users.

[edit] This remark appears to be in lots of the CSS files. It's still not compatible with CC though.
