### PR TITLE
Change padding to prevent text overlapping other text or design elements.

### DIFF
--- a/071/071.css
+++ b/071/071.css
@@ -49,7 +49,7 @@ header h2 {
 }
 .preamble {
 	background: transparent url(crossing.gif) left bottom no-repeat;
-	padding: 0 95px 230px 395px;
+	padding: 0 95px 330px 395px;
 }
 .supporting {
 	position: relative;
@@ -60,7 +60,7 @@ header h2 {
 	padding: 0 395px 0 95px;
 }
 .participation {
-	padding: 0 395px 180px 95px;
+	padding: 0 395px 120px 95px;
 	background: transparent url(wave.gif) left bottom no-repeat;
 }
 .benefits {
@@ -76,7 +76,7 @@ header h2 {
 	padding: 0 95px 0 0;
 }
 footer {
-	padding: 0 95px 5px 395px;
+	padding: 150px 95px 5px 395px;
 	background: transparent url(lines3.gif) left top repeat-y;
 }
 .sidebar {


### PR DESCRIPTION
This is a fix for Issue #95.

Two problems are fixed here:
1) the Resources section no longer extends longer than the blue area afforded it.
2) the Footer doesn't overlap the content just above it.

Note: I'm guessing about the designer's intent a LITTLE in terms of padding. But hey, no overlap.