### PR TITLE
Html-escape the $currentStyleSheet variable

### DIFF
--- a/includes/tmpl.php
+++ b/includes/tmpl.php
@@ -4,7 +4,7 @@
 	<meta charset="utf-8">
 	<title><?php echo $head["title"]; ?></title>
 
-	<link rel="stylesheet" media="screen" href="<?php echo $currentStyleSheet; ?>?v=8may2013">
+	<link rel="stylesheet" media="screen" href="<?php echo htmlentities($currentStyleSheet); ?>?v=8may2013">
 	<link rel="alternate" type="application/rss+xml" title="RSS" href="<?php echo $zenUrls["zen-rss"]; ?>">
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
The `$currentStyleSheet` variable may be populated by a `GET` request parameter (`?cssfile=foo`) from the client, and is included without being escaped. As such, an XSS vulnerability can be triggered by simply closing the tag and including any arbitrary content or scripts.

http://www.csszengarden.com/?cssfile=http:%22%3E%3Cscript%3Ealert(%27hello%27)%3C/script%3E

I understand that content injection and XSS are not particularly important on a site like csszengarden.com, but I believe that this change is nonetheless an improvement.

Thank you for your consideration.