### PR TITLE
Removing the need for a .php extension on all top level pages

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -24,13 +24,8 @@ RedirectMatch 301 ^/zengarden-sample\.html$ /examples/index.html
 RedirectMatch 301 ^/examples/index/$ /examples/index.php
 
 # clean up content page URLs
-# RedirectMatch 301 ^/pages/alldesigns/$ /pages/alldesigns.php
-# RedirectMatch 301 ^/pages/faq/$ /pages/faq.php
-# RedirectMatch 301 ^/pages/resources/$ /pages/resources.php
-# RedirectMatch 301 ^/pages/submit/$ /pages/submit.php
-
-
-
+RewriteCond %{REQUEST_FILENAME}.php -f
+RewriteRule !.*\.php$ %{REQUEST_FILENAME}.php [QSA,L]
 
 # REWRITE for CLEANER URL STRUCTURE
 #

--- a/includes/urls.php
+++ b/includes/urls.php
@@ -14,13 +14,13 @@ $zenUrls = array(
 
 
 	// sidebar links, some used in a few places
-	"zen-view-all" => "/pages/alldesigns.php",
-	"zen-resources" => "/pages/resources.php",
-	"zen-submit" => "/pages/submit.php",
-	"zen-faq" => "/pages/faq.php",
-	"zen-translations" => "/pages/translations.php",
-	"zen-guidelines" => "/pages/submit/guidelines.php",
-	"zen-about" => "/pages/about.php",
+	"zen-view-all" => "/pages/alldesigns/",
+	"zen-resources" => "/pages/resources/",
+	"zen-submit" => "/pages/submit/",
+	"zen-faq" => "/pages/faq/",
+	"zen-translations" => "/pages/translations/",
+	"zen-guidelines" => "/pages/submit/guidelines/",
+	"zen-about" => "/pages/about/",
 
 
 	// footer links, some used in multiple places


### PR DESCRIPTION
Hey Dave, this PR is regarding the Mastodon message at https://tilde.zone/@daveshea/110101607656699797

I've added an .htaccess rule that redirects all .php files to not require the .php extension to work. Tested locally on an Apache server running PHP 8.1.

I've also updated sidebar links to match the new format, though the `.php` version of pages should auto-redirect anyway for backlink support.