### PR TITLE
Fix: empty example html

### DIFF
--- a/examples/index.php
+++ b/examples/index.php
@@ -8,7 +8,7 @@
 ob_start();
 
 // pull in the source file for output, assign to $file variable
-include($_SERVER['DOCUMENT_ROOT'] . "src.php");
+include($_SERVER['DOCUMENT_ROOT'] . "/examples/src.php");
 $file = ob_get_contents();
 
 // close up buffering

--- a/examples/src.php
+++ b/examples/src.php
@@ -2,19 +2,19 @@
 
 
     // import URLs
-    include($_SERVER['DOCUMENT_ROOT'] . "../includes/urls.php");
+    include($_SERVER['DOCUMENT_ROOT'] . "/includes/urls.php");
 
 	// import language file
-	include($_SERVER['DOCUMENT_ROOT'] . "../lang/en.php");
+	include($_SERVER['DOCUMENT_ROOT'] . "/lang/en.php");
 
 	// import common functions & the design list
-	include($_SERVER['DOCUMENT_ROOT'] . '../includes/masterlist.php');
-	include($_SERVER['DOCUMENT_ROOT'] . "../includes/functions.php");
+	include($_SERVER['DOCUMENT_ROOT'] . '/includes/masterlist.php');
+	include($_SERVER['DOCUMENT_ROOT'] . "/includes/functions.php");
 
 	// reset current stylesheet to the example provided
 	$currentStyleSheet = "style.css";
 
     // import the HTML template
-	include($_SERVER['DOCUMENT_ROOT'] . "../includes/tmpl.php");
+	include($_SERVER['DOCUMENT_ROOT'] . "/includes/tmpl.php");
 
 ?>


### PR DESCRIPTION
Changes the include paths in examples/index.php and examples/src.php. These changes allow for the html file to be downloaded with content.


This pr should resolve resolve #121 